### PR TITLE
feat: Add Docker support for the application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+# Stage 1: Build the application
+FROM golang:1.22-alpine AS builder
+
+WORKDIR /app
+
+# Copy dependency manifests first to leverage Docker cache
+COPY go.mod go.sum* ./
+
+# Download dependencies
+RUN go mod download
+
+# Copy the entire source code including templates
+# This ensures templates are available in the builder stage if needed,
+# and importantly, for copying to the final stage later.
+COPY . .
+
+# Build the Go app, compiling all .go files in the current directory
+# -ldflags="-w -s" reduces the size of the binary by removing debug information
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o /identity-go .
+
+# Stage 2: Create the final lightweight runtime image
+FROM alpine:latest
+
+WORKDIR /app
+
+# Copy only the compiled binary from the builder stage
+COPY --from=builder /identity-go /identity-go
+
+# Copy the templates directory from the builder stage's source copy
+# The source path is /app/templates because WORKDIR was /app and we did COPY . .
+COPY --from=builder /app/templates ./templates
+
+# Expose the port the application listens on
+EXPOSE 8080
+
+# Command to run the executable when the container starts
+CMD ["/identity-go"] 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ This example uses hardcoded configuration values and `compose.Compose` for setti
 ```
 The server will start listening on `http://localhost:8080`.
 
+## Running with Docker
+
+Alternatively, you can build and run the application using Docker, avoiding the need to install Go dependencies locally.
+
+1.  **Build the Docker Image:**
+    ```bash
+    docker build -t identity-go-app .
+    ```
+    This command builds the Docker image using the `Dockerfile` in the root directory and tags it as `identity-go-app`.
+
+2.  **Run the Docker Container:**
+    ```bash
+    docker run -p 8080:8080 identity-go-app
+    ```
+    This command starts a container from the `identity-go-app` image and maps port 8080 on your host machine to port 8080 inside the container.
+
+    The server will start listening, and you can access it at `http://localhost:8080` in your browser.
+
 ## Endpoints
 
 *   `/oauth2/auth`: Authorization endpoint.


### PR DESCRIPTION
**feat: Add Docker Support**

**Description:**

This pull request introduces Docker support for the Go OAuth2 server application. It allows developers and users to build and run the application within a container, eliminating the need to install Go and its dependencies directly on the host machine.

**Changes:**

*   **Added `Dockerfile`:** A multi-stage Dockerfile has been added to the project root.
    *   The build stage uses the `golang:1.22-alpine` image to compile the application.
    *   The final stage uses a minimal `alpine:latest` image and copies only the compiled binary and the necessary `templates` directory, resulting in a smaller runtime image.
*   **Updated `README.md`:**
    *   Added a new section titled "Running with Docker".
    *   Included clear instructions and commands for building the Docker image (`docker build`) and running the container (`docker run`).

**Benefits:**

*   **Simplified Setup:** No need to install Go or manage dependencies locally.
*   **Environment Consistency:** Ensures the application runs in the same environment regardless of the host machine setup.
*   **Easier Deployment:** Containerization simplifies deployment processes.

**How to Test:**

1.  Build the Docker image: `docker build -t identity-go-app .`
2.  Run the container: `docker run -p 8080:8080 identity-go-app`
3.  Access the application in your browser at `http://localhost:8080`.
4.  Verify that the OAuth2 flows (e.g., accessing `/oauth2/auth`) work correctly and the login/consent pages render.